### PR TITLE
Module for Gene ID lookup and formatting gene objects.

### DIFF
--- a/src/utils/geneset_utils.py
+++ b/src/utils/geneset_utils.py
@@ -2,13 +2,27 @@ import mygene
 
 
 class IDLookup:
+    """Query a list of IDs and scope against mygene.info.
+    Attributes:
+        species (str, int): Species common name or taxid.
+        query_cache (dict, optional): Dictionary to store queries (keys)
+            and results (values). Defaults to empty dictionary.
+        ids (iterable): Array or set of ids to query by default.
+        Todo: if scope is 'retired', make a note that original id is retired.
+    """
+
     def __init__(self, species, cache_dict={}):
         self.species = species
         self.query_cache = cache_dict
 
     def query_mygene(self, ids, id_type):
-        """Query information from mygene.info about each gene in 'ids'."""
-        # TO DO: if scope is 'retired', make a note that original id is retired.
+        """Query information from mygene.info about each gene in 'ids'.
+        Args:
+            ids (iterable): Array or set of gene ids to query.
+            id_type (str): query scope field for the ids.
+                Can be a comma-separated string for multiple scopes.
+                e.g. 'entrezgene,symbol'
+        """
         self.ids = ids
         mg = mygene.MyGeneInfo()
         # Fields to query
@@ -46,8 +60,11 @@ class IDLookup:
 
     def retry_failed_with_new_ids(self, new_ids, new_id_type):
         """Retry failed queries with a new set of ids.
-        new_ids is a list where elements match the length and order
-        of self.ids"""
+        Only retries for ids that failed using 'self.query_mygene()'.
+        Args:
+            new_ids (iterable): is a list or set where the number of elements
+                matches the length and order of self.ids.
+            new_id_type (str): query scope for the new set of ids."""
         id_map = {i: j for i, j in zip(self.ids, new_ids)}
         retry_list = [id_map[e] for e in self.missing]
         self.query_mygene(retry_list, new_id_type)

--- a/src/utils/geneset_utils.py
+++ b/src/utils/geneset_utils.py
@@ -1,0 +1,54 @@
+import mygene
+
+
+class IDLookup:
+    def __init__(self, species, cache_dict={}):
+        self.species = species
+        self.query_cache = cache_dict
+
+    def query_mygene(self, ids, id_type):
+        """Query information from mygene.info about each gene in 'ids'."""
+        # TO DO: if scope is 'retired', make a note that original id is retired.
+        self.ids = ids
+        mg = mygene.MyGeneInfo()
+        # Fields to query
+        fields = "entrezgene,ensembl.gene,uniprot.Swiss-Prot,symbol,name,locus_tag"
+        response = mg.querymany(ids,
+                                scopes=id_type,
+                                fields=fields,
+                                species=self.species,
+                                returnall=True)
+        # Save failed queries
+        self.missing = response['missing']
+        # Format successful queries
+        for out in response['out']:
+            query = out['query']
+            if out.get('notfound'):
+                continue
+            gene = {'mygene_id': out['_id']}
+            if out.get('symbol') is not None:
+                gene['symbol'] = out['symbol'],
+            if out.get('name') is not None:
+                gene['name'] = out['name']
+            if out.get('entrezgene') is not None:
+                gene['ncbigene'] = out['entrezgene']
+            if out.get('ensembl') is not None:
+                if len(out['ensembl']) > 1:
+                    for i in out['ensembl']:
+                        gene.setdefault('ensemblgene', []).append(i['gene'])
+                else:
+                    gene['ensemblgene'] = out['ensembl']['gene']
+            if out.get('uniprot') is not None:
+                gene['uniprot'] = out['uniprot']['Swiss-Prot']
+            if out.get('locus_tag') is not None:
+                gene['locus_tag'] = out['locus_tag']
+            self.query_cache[query] = gene
+
+    def retry_failed_with_new_ids(self, new_ids, new_id_type):
+        """Retry failed queries with a new set of ids.
+        new_ids is a list where elements match the length and order
+        of self.ids"""
+        id_map = {i: j for i, j in zip(self.ids, new_ids)}
+        retry_list = [id_map[e] for e in self.missing]
+        self.query_mygene(retry_list, new_id_type)
+        mg = mygene.MyGeneInfo()

--- a/src/utils/geneset_utils.py
+++ b/src/utils/geneset_utils.py
@@ -1,5 +1,5 @@
 import mygene
-
+from biothings.utils.dataload import unlist
 
 class IDLookup:
     """Query a list of IDs and scope against mygene.info.
@@ -56,6 +56,7 @@ class IDLookup:
                 gene['uniprot'] = out['uniprot']['Swiss-Prot']
             if out.get('locus_tag') is not None:
                 gene['locus_tag'] = out['locus_tag']
+            gene = unlist(gene)
             self.query_cache[query] = gene
 
     def retry_failed_with_new_ids(self, new_ids, new_id_type):


### PR DESCRIPTION
The idea is to have a general module that can be used by any mygeneset plugin to generate gene objects, thus reducing code duplication, facilitating standardization, and providing a single point to introduce changes to that part of the schema.

This module has simple features:

Search using any supported query scope and taxonomic id.
Store queries as an in-memory dictionary of formatted responses and results.
Allow for re-trying failed queries using different sets of ids. For example, if you have a dataset with entrez ids, and gene symbols, you can query entrez ids first, then submit a query with corresponding gene symbols for entrez ids that failed.



