### PR TITLE
Modify DEFAULT_FIELDS to provide better default response records.

### DIFF
--- a/src/config_web.py
+++ b/src/config_web.py
@@ -95,7 +95,8 @@ ANNOTATION_KWARGS['*'].update(SPECIES_TYPEDEF)
 
 QUERY_KWARGS = copy.deepcopy(QUERY_KWARGS)
 QUERY_KWARGS['*'].update(SPECIES_TYPEDEF)
-DEFAULT_FIELDS = ['_id', 'genes', 'is_public', 'taxid']
+DEFAULT_FIELDS = ['_id', 'genes', 'name', 'description', 'source',
+                  'author', 'date', 'taxid']
 QUERY_KWARGS['*']['_source']['default'] = DEFAULT_FIELDS
 
 QUERY_KWARGS['POST']['scopes']['default'] =  ['_id', 'name']


### PR DESCRIPTION
Add the recently added 'name', 'source', and 'description' fields. Remove 'is_public': 'is_public' is a field that is not very useful to return by default, as it is only used in the back-end to decide whether an object is private, and thus should be shown only to a certain authenticated user.