### PR TITLE
Add tornado handler for launching webapp

### DIFF
--- a/src/config_web.py
+++ b/src/config_web.py
@@ -43,7 +43,6 @@ APP_LIST += [
         (r"/{ver}/user_geneset/([^/]+)/?", "web.handlers.api.UserGenesetHandler"),
         (r"/user_info", "web.handlers.login.UserInfoHandler"),
         (r"/logout", "web.handlers.login.LogoutHandler"),
-        (r"/login", "home.mockLogin"),
         (r"/login/github", "web.handlers.auth.GitHubLoginHandler"),
         (r"/login/orcid", "web.handlers.auth.ORCIDLoginHandler")
         ]

--- a/src/index.py
+++ b/src/index.py
@@ -1,4 +1,35 @@
+import os
+
+from tornado.options import define, options
+from tornado.web import RequestHandler
+
 from biothings.web.launcher import main
 
+from config import FRONTEND_PATH
+
+#FRONTEND_PATH = "/home/ravila/Projects/mygeneset.info-website"
+ASSETS_PATH = os.path.join(FRONTEND_PATH, 'dist/')
+define("webapp", default=False, help="Run server with frontend webapp.")
+
+
+class WebAppHandler(RequestHandler):
+    def get(self):
+        self.render(os.path.join(FRONTEND_PATH, 'dist/index.html'))
+
+
 if __name__ == "__main__":
-    main()
+    options.parse_command_line()
+    # Run with webapp
+    if options.webapp:
+        main([
+            (r"/", WebAppHandler),
+            (r"/css/(.*)", "tornado.web.StaticFileHandler", {
+                "path": os.path.join(ASSETS_PATH, "css")}),
+            (r"/js/(.*)", "tornado.web.StaticFileHandler", {
+                "path": os.path.join(ASSETS_PATH, "js")}),
+            (r"/img/(.*)", "tornado.web.StaticFileHandler", {
+                "path": os.path.join(ASSETS_PATH, "img")})
+        ])
+    else:
+        # Run only backend
+        main()


### PR DESCRIPTION
Allows serving the frontend in the alongside the backend by passing the `--webapp` flag to index.py