### PR TITLE
Create a custom mapper to count number of genes

### DIFF
--- a/src/bin/hub.py
+++ b/src/bin/hub.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 import os
-import config
+from functools import partial
+
 import biothings
+import config
 from biothings.utils.version import set_versions
 
 app_folder,_src = os.path.split(os.path.split(os.path.split(os.path.abspath(__file__))[0])[0])
@@ -9,11 +11,26 @@ set_versions(config, app_folder)
 biothings.config_for_app(config)
 logging = config.logger
 
-
+import biothings.hub.databuild.builder as builder
 from biothings.hub import HubServer
-import hub.dataload.sources
 
-server = HubServer(hub.dataload.sources, name=config.HUB_NAME)
+import hub.dataload.sources
+from hub.databuild.mapper import MyGenesetMapper
+
+
+class MyGenesetHubServer(HubServer):
+
+    def configure_build_manager(self):
+        mygeneset_mapper = MyGenesetMapper(name="count_genes")
+        partial_builder = partial(builder.DataBuilder, mappers=[mygeneset_mapper])
+        build_manager = builder.BuilderManager(job_manager=self.managers["job_manager"],
+                                               builder_class=partial_builder)
+        build_manager.configure()
+        build_manager.poll()
+        self.managers["build_manager"] = build_manager
+
+
+server = MyGenesetHubServer(hub.dataload.sources, name=config.HUB_NAME)
 
 
 if __name__ == "__main__":

--- a/src/hub/databuild/mapper.py
+++ b/src/hub/databuild/mapper.py
@@ -1,0 +1,17 @@
+import biothings, config
+biothings.config_for_app(config)
+
+import biothings.hub.databuild.mapper as mapper
+
+
+
+class MyGenesetMapper(mapper.BaseMapper):
+    """"Count the number of genes in each geneset"""
+
+    def load(self):
+        pass
+
+    def process(self, docs):
+        for doc in docs:
+            doc['count'] = len(doc['genes'])
+        yield doc


### PR DESCRIPTION
Custom mapper for counting genes in a geneset at build time. 

`MyGenesetMapper` should enable adding gene counts to documents without modifying a parser, if you set `{"mapper": "count_genes"}` in the `__metadata__` dictionary of a data source's  uploader.py