### PR TITLE
Improve msigdb

### DIFF
--- a/src/plugins/msigdb/parser.py
+++ b/src/plugins/msigdb/parser.py
@@ -30,8 +30,10 @@ def parse_msigdb(data_file):
         # Each document is a single gene set.
         # Documents have been sorted by their ORGANISM attribute using sort_genesets.xsl in post_dump() of dump.py
         current_organism = ""
+        geneset_index = 0
         for line in f:
             if line.lstrip().startswith("<GENESET"):
+                geneset_index += 1
                 doc = {}
                 tree = ET.fromstring(line)
                 assert tree.tag == "GENESET", "Expected GENESET tag"
@@ -82,6 +84,7 @@ def parse_msigdb(data_file):
                 else:
                     scopes = "symbol,ensembl.gene,entrezgene,uniprot,reporter,refseq,alias,unigene"
                 # Run query
+                logging.info("Queryng genes for geneset #{}: {}".format(geneset_index, doc["_id"]))
                 gene_lookup.query_mygene(id_list, ['symbol,alias', scopes])
                 query_results = gene_lookup.get_results(id_list)
                 doc.update(query_results)  # Merge doc with query results

--- a/src/plugins/msigdb/parser.py
+++ b/src/plugins/msigdb/parser.py
@@ -55,13 +55,14 @@ def parse_msigdb(data_file):
                     members = [s.split(",")[0] for s in data["MEMBERS_MAPPING"].split("|")]
                 assert len(members) == len(symbols), "ID lists are not the same length: {} {}".format(
                     len(members), len(symbols))
-                id_list = list(zip(members, symbols))
+                # Using symbols as the preferred id, because it consistently gives the most hits across datasets
+                id_list = list(zip(symbols, members))
                 if doc["taxid"] != current_organism:
                     # Start a new query cache
                     current_organism = doc["taxid"]
                     logging.info("Parsing msigdb data for organism {}".format(current_organism))
                     gene_lookup = IDLookup(doc["taxid"])
-                # Figure out which scopes to use
+                # Figure out which scopes to use for the retry query
                 original_type = data.get("CHIP")
                 if original_type:
                     if original_type.endswith("GENE_SYMBOL") or original_type == "HGNC_ID":
@@ -81,7 +82,7 @@ def parse_msigdb(data_file):
                 else:
                     scopes = "symbol,ensembl.gene,entrezgene,uniprot,reporter,refseq,alias,unigene"
                 # Run query
-                gene_lookup.query_mygene(id_list, [scopes, 'symbol,alias'])
+                gene_lookup.query_mygene(id_list, ['symbol,alias', scopes])
                 # Save resuls
                 genes = []
                 missing = []

--- a/src/plugins/msigdb/parser.py
+++ b/src/plugins/msigdb/parser.py
@@ -83,29 +83,8 @@ def parse_msigdb(data_file):
                     scopes = "symbol,ensembl.gene,entrezgene,uniprot,reporter,refseq,alias,unigene"
                 # Run query
                 gene_lookup.query_mygene(id_list, ['symbol,alias', scopes])
-                # Save resuls
-                genes = []
-                missing = []
-                dups = []
-                for i, j in id_list:
-                    if gene_lookup.query_cache.get(i) is not None:
-                        if isinstance(gene_lookup.query_cache[i], list):
-                            genes += gene_lookup.query_cache[i]
-                            dups.append((i, [g['mygene_id'] for g in gene_lookup.query_cache[i]]))
-                        else:
-                             genes.append(gene_lookup.query_cache[i])
-                    elif gene_lookup.query_cache.get(j) is not None:
-                        if isinstance(gene_lookup.query_cache[j], list):
-                            genes += gene_lookup.query_cache[j]
-                            dups.append((j, [g['mygene_id'] for g in gene_lookup.query_cache[j]]))
-                        else:
-                            genes.append(gene_lookup.query_cache[j])
-                    else:
-                        missing.append(i)
-                doc["genes"] = genes
-                doc["original_ids"] = members
-                doc["not_found"] = missing
-                doc["duplicates"] = dups
+                query_results = gene_lookup.get_results(id_list)
+                doc.update(query_results)  # Merge doc with query results
                 # Additional msigdb data
                 msigdb = {}
                 msigdb["id"] = data["STANDARD_NAME"]
@@ -140,5 +119,5 @@ if __name__ == "__main__":
     assert os.path.exists(xmlfile), "Could not find input XML file."
     annotations = parse_msigdb(xmlfile)
     for a in annotations:
-        pass
-        #print(json.dumps(a, indent=2))
+        #pass
+        print(json.dumps(a, indent=2))

--- a/src/plugins/msigdb/parser.py
+++ b/src/plugins/msigdb/parser.py
@@ -46,46 +46,66 @@ def parse_msigdb(data_file):
                 doc["is_public"] = True
                 assert doc["taxid"] is not None, "Taxid not found. ORGANISM missing in source data: {}".format(data)
                 assert doc["taxid"] != "", "Taxid not found. ORGANISM missing in source data: {}".format(data)
-                # MEMBERS contains a list of genes with their original identifier, which can be any type of ID.
-                # symbols contains a list of genes converted to symbols.
-                # MEMBERS_EZID contains a list of gene entrez IDs, but these have been converted from their corresponding human gene.
-                # MEMBERS_MAPPING contains tuples of the three above IDs.
-                members =  data["MEMBERS"].split(",")
-                symbols = [s.split(",")[1] for s in data["MEMBERS_MAPPING"].split("|")]
+                # Start a gene query
+                if doc["taxid"] != current_organism:
+                    current_organism = doc["taxid"]
+                    logging.info("Parsing msigdb data for organism {}".format(current_organism))
+                    gene_lookup = IDLookup(doc["taxid"])
+                # MEMBERS contains a "," delimited list of genes with their original identifier.
+                # MEMBERS_SYMBOLIZED contains a "," delimited list of genes converted to symbols (but sometimes containsother types of ids).
+                # MEMBERS_EZID contains a "," delimited list of entrez IDs, but these have been converted from their corresponding human gene.
+                # MEMBERS_MAPPING contains "|" delimited "," delimited tuples of the three above IDs.
+                # Figure out which scopes to use for the MEMBERS set
+                original_type = data.get("CHIP")
+                if original_type:
+                    if original_type.endswith("GENE_SYMBOL") or original_type == "HGNC_ID":
+                        members_scopes = 'symbol,alias'
+                    elif original_type.endswith("UniProt_ID"):
+                        members_scopes = 'uniprot'
+                    elif original_type.endswith("Ensembl_Gene_ID"):
+                        members_scopes = 'ensembl.gene'
+                    elif original_type.endswith("RefSeq"):
+                        members_scopes = 'refseq'
+                    elif original_type.endswith("NCBI_Gene_ID"):
+                        members_scopes = 'entrezgene,retired'
+                    elif original_type == "UniGene_ID":
+                        members_scopes = 'unigene'
+                    else:
+                        # default to all
+                        members_scopes = "symbol,ensembl.gene,entrezgene,uniprot,reporter,refseq,alias,unigene"
+                else:
+                    members_scopes = "symbol,ensembl.gene,entrezgene,uniprot,reporter,refseq,alias,unigene"
+                if "|" in data['MEMBERS']:
+                    # Sometimes ids contain a "|" with a prefix like 'ens', or 'linc'
+                    # to indicate the id type is different from the rest.
+                    # We can't use this to determine the scope, so we'll just use the default.
+                    members_scopes = "symbol,ensembl.gene,entrezgene,uniprot,reporter,refseq,alias,unigene"
+                # Prepare list of genes to query. We will query gene symbols and original ids.
+                members_mapping = [s.split(",") for s in data["MEMBERS_MAPPING"].split("|") if len(s.split(",")) == 3]
+                symbols = []
+                for id_tuple in members_mapping:
+                    if id_tuple[1] == "":
+                        symbols.append(id_tuple[0])  # If no symbol, use the original ID
+                    else:
+                        symbols.append(id_tuple[1])
+                members_raw =  data["MEMBERS"].split(",")
+                members = []
+                for m in members_raw:
+                    if "|" in m:
+                        # Remove prefixes like 'ens' or 'linc'
+                        members.append(m.split("|")[1])
+                    else:
+                        members.append(m)
                 if len(members) != len(symbols):
                     # This edge case shouldn't happen, but we can use another altnative
-                    members = [s.split(",")[0] for s in data["MEMBERS_MAPPING"].split("|")]
+                    members = [s.split(",")[0] for s in data["MEMBERS_MAPPING"].split("|") if len(s.split(",")) == 3]
                 assert len(members) == len(symbols), "ID lists are not the same length: {} {}".format(
                     len(members), len(symbols))
                 # Using symbols as the preferred id, because it consistently gives the most hits across datasets
                 id_list = list(zip(symbols, members))
-                if doc["taxid"] != current_organism:
-                    # Start a new query cache
-                    current_organism = doc["taxid"]
-                    logging.info("Parsing msigdb data for organism {}".format(current_organism))
-                    gene_lookup = IDLookup(doc["taxid"])
-                # Figure out which scopes to use for the retry query
-                original_type = data.get("CHIP")
-                if original_type:
-                    if original_type.endswith("GENE_SYMBOL") or original_type == "HGNC_ID":
-                        scopes = 'symbol,alias'
-                    elif original_type.endswith("UniProt_ID"):
-                        scopes = 'uniprot'
-                    elif original_type.endswith("Ensembl_Gene_ID"):
-                        scopes = 'ensembl.gene'
-                    elif original_type.endswith("RefSeq"):
-                        scopes = 'refseq'
-                    elif original_type.endswith("NCBI_Gene_ID"):
-                        scopes = 'entrezgene,retired'
-                    elif original_type == "UniGene_ID":
-                        scopes = 'unigene'
-                    else:
-                        scopes = "symbol,ensembl.gene,entrezgene,uniprot,reporter,refseq,alias,unigene"
-                else:
-                    scopes = "symbol,ensembl.gene,entrezgene,uniprot,reporter,refseq,alias,unigene"
                 # Run query
                 logging.info("Queryng genes for geneset #{}: {}".format(geneset_index, doc["_id"]))
-                gene_lookup.query_mygene(id_list, ['symbol,alias', scopes])
+                gene_lookup.query_mygene(id_list, ['symbol,alias', members_scopes])
                 query_results = gene_lookup.get_results(id_list)
                 doc.update(query_results)  # Merge doc with query results
                 # Additional msigdb data

--- a/src/plugins/msigdb/upload.py
+++ b/src/plugins/msigdb/upload.py
@@ -45,9 +45,16 @@ class msigdbUploader(uploader.BaseSourceUploader):
                     "all"
                 ]
             },
+            "count": {
+                "type": "integer"
+            },
             "genes": {
                 "properties": {
                     "mygene_id": {
+                        "normalizer": "keyword_lowercase_normalizer",
+                        "type": "keyword"
+                    },
+                    "source_id": {
                         "normalizer": "keyword_lowercase_normalizer",
                         "type": "keyword"
                     },
@@ -72,6 +79,35 @@ class msigdbUploader(uploader.BaseSourceUploader):
                     }
                 }
             },
+            "duplicates": {
+                "properties": {
+                    "dups": {
+                        "properties": {
+                            "id": {
+                                "normalizer": "keyword_lowercase_normalizer",
+                                "type": "keyword"
+                            },
+                            "count": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "count": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "not_found": {
+                "properties": {
+                    "ids": {
+                        "normalizer": "keyword_lowercase_normalizer",
+                        "type": "keyword"
+                    },
+                    "count": {
+                        "type": "integer"
+                    }
+                }
+            },
             "msigdb": {
                 "properties": {
                     "id": {
@@ -83,6 +119,10 @@ class msigdbUploader(uploader.BaseSourceUploader):
                     },
                     "geneset_name": {
                         "type": "text",
+                    },
+                    "systematic_name": {
+                        "normalizer": "keyword_lowercase_normalizer",
+                        "type": "keyword"
                     },
                     "category_code": {
                         "normalizer": "keyword_lowercase_normalizer",
@@ -102,6 +142,10 @@ class msigdbUploader(uploader.BaseSourceUploader):
                         "type": "text"
                     },
                     "source": {
+                        "normalizer": "keyword_lowercase_normalizer",
+                        "type": "keyword"
+                    },
+                    "source_identifier": {
                         "normalizer": "keyword_lowercase_normalizer",
                         "type": "keyword"
                     },

--- a/src/utils/geneset_utils.py
+++ b/src/utils/geneset_utils.py
@@ -78,10 +78,9 @@ class IDLookup:
         while current_try <= retry_times:
             # Remove ids that already in the cache
             if retry:
-                new_ids = [n for n in ids if n[current_try]
-                           not in self.query_cache.keys()]
+                new_ids = [n for n in ids if n[current_try] not in self.query_cache]
             else:
-                new_ids = [n for n in ids if n not in self.query_cache.keys()]
+                new_ids = [n for n in ids if n not in self.query_cache]
             diff = len(ids) - len(new_ids)
             assert diff >= 0, "This shouldn't have happened!"
             if diff > 0:

--- a/src/utils/geneset_utils.py
+++ b/src/utils/geneset_utils.py
@@ -187,6 +187,8 @@ class IDLookup:
         results = {}
         results['genes'] = genes
         results["count"] = len(genes)
-        results['duplicates'] = {'dups': dups, 'count': len(dups)}
-        results['not_found'] = {'ids': missing, 'count': len(missing)}
+        if len(dups) > 0:
+            results['duplicates'] = {'dups': dups, 'count': len(dups)}
+        if len(missing) > 0:
+            results['not_found'] = {'ids': missing, 'count': len(missing)}
         return results

--- a/src/utils/geneset_utils.py
+++ b/src/utils/geneset_utils.py
@@ -85,9 +85,9 @@ class IDLookup:
             assert diff >= 0, "This shouldn't have happened!"
             if diff > 0:
                 logging.info(f"Found {diff} genes in query cache.")
-            ids = new_ids
-            if len(ids) == 0:
+            elif len(ids) == 0:
                 continue
+            ids = new_ids
             logging.info(f"Searching for {len(ids)} genes...")
             # Generate params for query
             if retry:


### PR DESCRIPTION
Fix outstanding issues with parser and geneset utilites.
`geneset_utils.py` has a new function `get_results()` that simplifies a lot of boilerplate code in the parser.
Also, this module adds new top-level fields to genesets `duplicates`, `not_found`, `count`, as well as `source_id` under the `genes` field.

Query speedups were achieved by reversing the order of search/retry lists. By preferring gene symbols, we are able to retrieve most genes with a single query, versus using the original ids.
Fixes bugs in the parser that were causing some genes to be missed or queried incorrectly.


 