### PR TITLE
Add local and remote tests

### DIFF
--- a/src/tests/bot.py
+++ b/src/tests/bot.py
@@ -1,0 +1,27 @@
+from seleniumwire import webdriver
+from selenium.common.exceptions import NoSuchElementException
+from webdriver_manager.chrome import ChromeDriverManager, ChromeType
+
+
+class Bot:
+    def start(self):
+        """Start a selenium web driver"""
+        chrome_options = webdriver.ChromeOptions()
+        #chrome_options.add_argument("--headless")
+        chrome_options.add_argument("--no-sandbox")
+        chrome_options.add_argument("--disable-gpu")
+        chrome_options.add_argument("--lang=en")
+        driver_path = ChromeDriverManager(chrome_type=ChromeType.CHROMIUM).install()
+        self.driver = webdriver.Chrome(driver_path, options=chrome_options)
+        self.driver.implicitly_wait(20)
+
+    def stop(self):
+        """Stop the selenium web driver"""
+        self.driver.quit()
+
+    def go_to_url(self, url):
+        """Go to a url"""
+        try:
+            self.driver.get(url)
+        except NoSuchElementException as ex:
+            self.fail(ex.msg)

--- a/src/tests/test_local.py
+++ b/src/tests/test_local.py
@@ -132,7 +132,3 @@ class TestUserGenesets(MyGenesetLocalTestBase):
             }
         }
         assert res.json() == expected_respone, "The response document does not match the expected one."
-
-
-if __name__ == '__main__':
-    TestUserLogin().test_login_github()

--- a/src/tests/test_local.py
+++ b/src/tests/test_local.py
@@ -117,6 +117,7 @@ class TestUserGenesets(MyGenesetLocalTestBase):
                 "name": "Test",
                 "author": "ravila4",
                 "is_public": True,
+                "count": 1,
                 "genes": [
                     {
                         "mygene_id": "1001",

--- a/src/tests/test_local.py
+++ b/src/tests/test_local.py
@@ -1,0 +1,138 @@
+
+import json
+import time
+import os
+
+from biothings.tests.web import BiothingsWebTest
+from selenium.webdriver.common.by import By
+from seleniumwire.utils import decode
+
+from .bot import Bot
+
+
+class MyGenesetLocalTestBase(BiothingsWebTest, Bot):
+    HOST = 'http://localhost:8000'
+    GITHUB_USERNAME = os.environ['GITHUB_USERNAME']
+    GITHUB_PASSWORD = os.environ['GITHUB_PASSWORD']
+    ORCID_USERNAME = os.environ['ORCID_USERNAME']
+    ORCID_PASSWORD = os.environ['ORCID_PASSWORD']
+    ORCID_ID = os.environ['ORCID_ID']
+
+
+class TestUserLogin(MyGenesetLocalTestBase):
+    def test_01_login_logout_github(self):
+        self.start()
+        # Test login
+        self.go_to_url(f'{self.HOST}/login/github')
+        time.sleep(2)
+        self.driver.find_element(By.ID, "login_field").send_keys(self.GITHUB_USERNAME)
+        self.driver.find_element(By.ID, "password").send_keys(self.GITHUB_PASSWORD)
+        self.driver.find_element("xpath", "//input[@value='Sign in']").click()
+        time.sleep(5)
+        cookies = self.driver.get_cookies()
+        for cookie in cookies:
+            if cookie['name'] == "user":
+                found_user_cookie = True
+                user_cookie = cookie['value']
+        assert found_user_cookie is True, "User cookie not found."
+        # Check user info
+        resp = self.request(f'{self.HOST}/user_info', cookies={"user": user_cookie})
+        assert resp.status_code == 200, "User info request failed."
+        assert resp.json()["username"] == self.GITHUB_USERNAME, "Unexpected username in user_info"
+        # Test logout
+        self.go_to_url(f'{self.HOST}/logout')
+        time.sleep(2)
+        for cookie in self.driver.get_cookies():
+            assert cookie['name'] != "user", "User cookie not removed."
+        self.stop()
+
+    def test_02_login_logout_orcid(self):
+        self.start()
+        # Test login
+        self.go_to_url(f'{self.HOST}/login/orcid')
+        time.sleep(2)
+        self.driver.find_element(By.ID, "username").send_keys(self.ORCID_USERNAME)
+        self.driver.find_element(By.ID, "password").send_keys(self.ORCID_PASSWORD)
+        self.driver.find_element(By.ID, "signin-button").click()
+        time.sleep(5)
+        cookies = self.driver.get_cookies()
+        for cookie in cookies:
+            if cookie['name'] == "user":
+                found_user_cookie = True
+                user_cookie = cookie['value']
+        assert found_user_cookie is True, "User cookie not found."
+        # Check user info
+        resp = self.request(f'{self.HOST}/user_info', cookies={"user": user_cookie})
+        assert resp.status_code == 200, "User info request failed."
+        assert resp.json()["username"] == self.ORCID_ID, "Unexpected username in user_info"
+        # Test logout
+        self.go_to_url(f'{self.HOST}/logout')
+        time.sleep(2)
+        for cookie in self.driver.get_cookies():
+            assert cookie['name'] != "user", "User cookie not removed."
+        self.stop()
+
+
+class TestUserGenesets(MyGenesetLocalTestBase):
+
+    def test_get_cookie(self):
+        self.start()
+        # Login and get user cookie
+        self.go_to_url(f'{self.HOST}/login/github')
+        time.sleep(2)
+        self.driver.find_element(By.ID, "login_field").send_keys(self.GITHUB_USERNAME)
+        self.driver.find_element(By.ID, "password").send_keys(self.GITHUB_PASSWORD)
+        self.driver.find_element("xpath", "//input[@value='Sign in']").click()
+        time.sleep(5)
+        cookies = self.driver.get_cookies()
+        for cookie in cookies:
+            if cookie['name'] == "user":
+                user_cookie = cookie['value']
+        # Write user cookie to file
+        with open('user_cookie.txt', 'w') as f:
+            f.write(user_cookie)
+        self.stop()
+
+    def test_create_geneset_dry_run(self):
+        payload = json.dumps(
+            {
+                "name": "Test",
+                "is_public": True,
+                "taxid": "9606",
+                "genes": ["1001"]
+            }
+        )
+        headers = {
+            'Content-Type': 'application/json',
+            'Cookie': 'user=%s' % open('user_cookie.txt').read()
+        }
+        res = self.request(
+            f'{self.HOST}/v1/user_geneset?dry_run=true',
+            method='POST',
+            headers=headers,
+            data=payload
+        )
+        assert res.status_code == 200, "Response status is not 200."
+        expected_respone = {
+            "new_document": {
+                "name": "Test",
+                "author": "ravila4",
+                "is_public": True,
+                "genes": [
+                    {
+                        "mygene_id": "1001",
+                        "source_id": "1001",
+                        "symbol": "CDH3",
+                        "name": "cadherin 3",
+                        "ncbigene": "1001",
+                        "ensemblgene": "ENSG00000062038",
+                        "uniprot": "P22223"
+                    }
+                ]
+            }
+        }
+        assert res.json() == expected_respone, "The response document does not match the expected one."
+
+
+if __name__ == '__main__':
+    TestUserLogin().test_login_github()

--- a/src/tests/test_local.py
+++ b/src/tests/test_local.py
@@ -5,7 +5,6 @@ import os
 
 from biothings.tests.web import BiothingsWebTest
 from selenium.webdriver.common.by import By
-from seleniumwire.utils import decode
 
 from .bot import Bot
 

--- a/src/tests/test_remote.py
+++ b/src/tests/test_remote.py
@@ -1,0 +1,92 @@
+
+from biothings.tests.web import BiothingsDataTest
+
+
+class MyGenesetWebTestBase(BiothingsDataTest):
+    host = 'mygeneset.info'
+
+
+class TestMyGenesetDataIntegrity(MyGenesetWebTestBase):
+
+    # --------------
+    # Query endpoint
+    # --------------
+
+    def test_query_default_fields(self):
+        self.query(q='glucose')
+
+    def test_query_field(self):
+        self.query(q='genes.ncbigene:1017')
+
+    def test_species_filter_blank_query(self):
+        dog = self.query(species='9615')
+        print(3, dog['hits'][0])
+        assert dog['hits'][0]['taxid'] == "9615"
+
+    def test_species_filter_plus_query(self):
+        dog = self.query(q='glucose', species='9615')
+        print(dog['hits'][0])
+        assert dog['hits'][0]['taxid'] == "9615"
+
+    def test_query_by_id(self):
+        _id = "WP100"
+        query = self.query(q=f"_id:{_id}")
+        assert query['hits'][0]['_id'] == _id
+
+    def test_query_by_name(self):
+        kinase = self.query(q='name:kinase')
+        assert 'kinase' in kinase['hits'][0]['name'].lower()
+
+    def test_query_by_description(self):
+        desc = self.query(q='description:cytosine deamination')
+        assert 'cytosine' in desc['hits'][0]['description'].lower()
+        assert 'deamination' in desc['hits'][0]['description'].lower()
+
+    def test_query_by_source_go(self):
+        go = self.query(q='source:go', fields='all')
+        assert 'go' in go['hits'][0].keys()
+        assert go['hits'][0]['source'] == 'go'
+
+    def test_query_by_source_ctd(self):
+        ctd = self.query(q='source:ctd', fields='all')
+        assert 'ctd' in ctd['hits'][0].keys()
+        assert ctd['hits'][0]['source'] == 'ctd'
+
+    def test_query_by_source_msigdb(self):
+        msigdb = self.query(q='source:msigdb', fields='all')
+        assert 'msigdb' in msigdb['hits'][0].keys()
+        assert msigdb['hits'][0]['source'] == 'msigdb'
+
+    def test_query_by_source_kegg(self):
+        kegg = self.query(q='source:kegg', fields='all')
+        assert 'kegg' in kegg['hits'][0].keys()
+        assert kegg['hits'][0]['source'] == 'kegg'
+
+    def test_query_by_source_do(self):
+        do = self.query(q='source:do', fields='all')
+        assert 'do' in do['hits'][0].keys()
+        assert do['hits'][0]['source'] == 'do'
+
+    def test_query_by_source_reactome(self):
+        reactome = self.query(q='source:reactome', fields='all')
+        assert 'reactome' in reactome['hits'][0].keys()
+        assert reactome['hits'][0]['source'] == 'reactome'
+
+    def test_query_by_source_smpdb(self):
+        smpdb = self.query(q='source:smpdb', fields='all')
+        assert 'smpdb' in smpdb['hits'][0].keys()
+        assert smpdb['hits'][0]['source'] == 'smpdb'
+
+    # TODO: Add POST endpoint tests
+
+    # -------------------
+    # Annotation endpoint
+    # -------------------
+
+    def test_annotation_default_fields(self):
+        geneset_id = "WP100"
+        res = self.request("geneset/" + geneset_id).json()
+        assert res['_id'] == geneset_id
+        expected_fields = ['genes', 'name', 'source', 'taxid', 'is_public', 'wikipathways']
+        for field in expected_fields:
+            assert field in res.keys()

--- a/src/web/handlers/api.py
+++ b/src/web/handlers/api.py
@@ -63,13 +63,20 @@ class UserGenesetHandler(BioThingsAuthnMixin, BaseAPIHandler):
         """"Take a list of mygene.info ids and return a list of gene objects."""
         mygene = MyGeneLookup(species="all", cache_dict={})
         mygene.query_mygene(genes, id_types="_id")
-        return [gene for gene in mygene._query_cache.values()]
+        results = mygene.get_results(genes)
+        return results
 
     async def _create_user_geneset(self, name, author, genes=[], is_public=True, description=""):
         """"Create a user geneset document."""
-        genes = await self._query_mygene(genes)
-        geneset = {"name": name, "author": author, "description": description,
-                   "is_public": is_public, "genes": genes}
+        geneset = await self._query_mygene(genes)
+        geneset.update(
+            {
+                "name": name,
+                "author": author,
+                "description": description,
+                "is_public": is_public
+            }
+        )
         geneset = dict_sweep(geneset, vals=[None])
         return geneset
 


### PR DESCRIPTION
- Create web tests for query and annotation endpoints.
- Create local tests for user login/logout and geneset creation.
- Add gene counts to user genesets.