### PR TITLE
Don't parse mouse geneset

### DIFF
--- a/src/plugins/msigdb/dump.py
+++ b/src/plugins/msigdb/dump.py
@@ -41,23 +41,28 @@ class msigdbDumper(HTTPDumper):
         return version
 
     def create_todump_list(self, force=False):
-        """Dump XML geneset file."""
+        """Dump XML geneset file.
+        NOTE: the "mouse" dataset was commented out because on inspection, it contains much of the same
+        data as the "human" dataset. In fact, both datasets contain genesets from multiple species,
+        only converted using homology. In the parser, we are taking the original ids, pre-homology conversion.
+        If we keep both datasets, it causes a lot of _id clashes because of this redundancy.
+        """
         self.release = self.get_remote_version()
         if force or not self.current_release or float(self.release) > float(self.current_release):
             home = self.__class__.BASE_URL
             long_version_str = "msigdb_v" + self.release  # Should have the format "msigdb_v2022.1"
             human_file_name = long_version_str + '.Hs_files_to_download_locally.zip'
-            mouse_file_name = long_version_str + '.Mm_files_to_download_locally.zip'
+            # mouse_file_name = long_version_str + '.Mm_files_to_download_locally.zip'
             # The url for human file should look like this:
             # https://data.broadinstitute.org/gsea-msigdb/msigdb/release/2022.1.Hs/msigdb_v2022.1.Hs_files_to_download_locally.zip
             human_url = home + self.release + '.Hs/' + human_file_name
             # The url for the mouse file should look like this:
             # https://data.broadinstitute.org/gsea-msigdb/msigdb/release/2022.1.Mm/msigdb_v2022.1.Mm_files_to_download_locally.zip
-            mouse_url = home + self.release + '.Mm/' + mouse_file_name
+            # mouse_url = home + self.release + '.Mm/' + mouse_file_name
             self.human_data_file = os.path.join(self.new_data_folder, human_file_name)
-            self.mouse_data_file = os.path.join(self.new_data_folder, mouse_file_name)
+            # self.mouse_data_file = os.path.join(self.new_data_folder, mouse_file_name)
             self.to_dump.append({"remote": human_url, "local": self.human_data_file})
-            self.to_dump.append({"remote": mouse_url, "local": self.mouse_data_file})
+            # self.to_dump.append({"remote": mouse_url, "local": self.mouse_data_file})
 
     def sort_xml(self, file, output_file):
         """Sort XML file by organism
@@ -79,6 +84,6 @@ class msigdbDumper(HTTPDumper):
         self.logger.info("Sorting documents in XML file")
         unzipall(self.new_data_folder)
         human_file_path = glob.glob(self.human_data_file.replace(".zip", "") + "/msigdb_v*.Hs.xml")
-        mouse_file_path = glob.glob(self.mouse_data_file.replace(".zip", "") + "/msigdb_v*.Mm.xml")
+        # mouse_file_path = glob.glob(self.mouse_data_file.replace(".zip", "") + "/msigdb_v*.Mm.xml")
         self.sort_xml(human_file_path[0], os.path.join(self.new_data_folder, "human_genesets.xml"))
-        self.sort_xml(mouse_file_path[0], os.path.join(self.new_data_folder, "mouse_genesets.xml"))
+        # self.sort_xml(mouse_file_path[0], os.path.join(self.new_data_folder, "mouse_genesets.xml"))

--- a/src/plugins/msigdb/parser.py
+++ b/src/plugins/msigdb/parser.py
@@ -51,20 +51,14 @@ def parse_msigdb(data_folder):
         "8": "cell type signature genesets"
     }
 
-    for f in ["human_genesets.xml", "mouse_genesets.xml"]:
+    for f in ["human_genesets.xml"]:
         data_file = os.path.join(data_folder, f)
+        # File contains newline-delimited XML documents. Each document is a single geneset.
+        # Documents have been sorted by their ORGANISM attribute using sort_genesets.xsl in post_dump() of dump.py
         with open(data_file, 'r') as f:
-            # File contains newline-delimited XML documents. Each document is a single gene set.
-            # Documents have been sorted by their ORGANISM attribute using sort_genesets.xsl in post_dump() of dump.py
             current_organism = ""
-            geneset_index = 0
+            geneset_index = 0  # Keep track of current line for logging/debugging purposes
             for line in f:
-                if line.lstrip().startswith("<MSIGDB NAME"):
-                    dataset_code = line.split(" ")[2][-3:-1]
-                    if dataset_code == "Hs":
-                        DATASET = "human"
-                    elif dataset_code == "Mm":
-                        DATASET = "mouse"
                 if line.lstrip().startswith("<GENESET"):
                     geneset_index += 1
                     doc = {}
@@ -147,7 +141,6 @@ def parse_msigdb(data_folder):
                     msigdb["id"] = data["STANDARD_NAME"]
                     msigdb["geneset_name"] = data["STANDARD_NAME"].replace("_", " ").lower()
                     msigdb["systematic_name"] = data["SYSTEMATIC_NAME"]
-                    msigdb["dataset"] = DATASET
                     msigdb["category"] = {}
                     msigdb["category"]["code"] = data["CATEGORY_CODE"]
                     msigdb["category"]["name"] = CATEGORY_CODES.get(data["CATEGORY_CODE"][-1])

--- a/src/plugins/msigdb/upload.py
+++ b/src/plugins/msigdb/upload.py
@@ -132,10 +132,6 @@ class msigdbUploader(uploader.BaseSourceUploader):
                         "normalizer": "keyword_lowercase_normalizer",
                         "type": "keyword"
                     },
-                    "dataset": {
-                        "normalizer": "keyword_lowercase_normalizer",
-                        "type": "keyword"
-                    },
                     "category": {
                         "properties": {
                             "code": {


### PR DESCRIPTION
I have reversed some changes that parse a "mouse" data file from msigdb. The reasoning after parsing that file, we had a lot of dupicated ids.

 Both the human file and mouse file are in fact homology-converted genesets that originate from experiments with other organisms. The parser is keeping the original organism and gene ids instead of the converted ones, so having another download for mouse data does not add much information.

Parsing the file also added a significant amount of runtime to the parser, increasing it from 6 hours to 8 hours, and after deduplication, did not yield many new documents.