### PR TITLE
Add taxid field via query_mygene_homolog

### DIFF
--- a/src/tests/test_mygene_lookup.py
+++ b/src/tests/test_mygene_lookup.py
@@ -164,6 +164,7 @@ class TestMyGeneLookup:
         results = lookup.get_results(mousegenes)
         assert results['count'] == 3
         assert [(g['source_id'], g['mygene_id'])for g in results['genes']] == mouse_to_human
+        assert any(g['taxid'] == 9606 for g in results['genes'])
 
     def test_031_homolog_convert_mouse_to_human_with_retries(self):
         """Convert mouse genes to human genes"""

--- a/src/utils/mygene_lookup.py
+++ b/src/utils/mygene_lookup.py
@@ -267,7 +267,7 @@ class MyGeneLookup:
         # We clear the cache because we have a new taxid and set of returned fields
         self.clear_cache()
         self.species = new_species
-        self.fields_to_query = ["entrezgene", "ensembl.gene", "uniprot.Swiss-Prot", "symbol", "name"]
+        self.fields_to_query = ["entrezgene", "ensembl.gene", "uniprot.Swiss-Prot", "symbol", "name", "taxid"]
         new_ids = list(set([conversion.homolog_gene_id for conversion in mappings]))
         if len(new_ids) == 0:
             logging.info("No ids to query.")


### PR DESCRIPTION
Fixes bug #69, where most genes from the CTD datasource are missing taxid field. 
Also added a check for taxid field in one of the mygeneset utils  tests to cover this case.

@newgene @everaldorodrigo Making this PR as it's a relatively quick fix for me. I tested by running the CTD uploader locally and seems fine.

