### PR TITLE
Get a count of all users in metadata (#83)

### DIFF
--- a/src/web/handlers/metadata.py
+++ b/src/web/handlers/metadata.py
@@ -35,7 +35,6 @@ class MyGenesetMetadataSourceHandler(MetadataSourceHandler):
         """Fetch a geneset document from Elasticsearch"""
         try:
             result = await self.biothings.elasticsearch.async_client.count(
-                    '{"query": {"exists": {"field": "author"}}}',
                     index=self.biothings.config.ES_USER_INDEX)
             return result['count']
         except NotFoundError:


### PR DESCRIPTION
Fix counting `user` field in metadata endpoint.
The `anonymous` is a subset of `users`.